### PR TITLE
🧹 cleanup: Remove redundant comments from setup scripts

### DIFF
--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -5,19 +5,16 @@ BINARY_NAME="commit_message"
 CUSTOM_BIN_DIR="$HOME/bin"
 BINARY_URL="https://github.com/MatthewAraujo/commit_message/releases/download/binary/commit_message-linux-amd64"
 
-# Ensure curl is available
 if ! command -v curl &>/dev/null; then
     echo "Error: curl is required but not installed. Please install curl and try again."
     exit 1
 fi
 
-# Create the custom directory if it doesn't exist
 if [[ ! -d "$CUSTOM_BIN_DIR" ]]; then
     echo "Creating directory: $CUSTOM_BIN_DIR"
     mkdir -p "$CUSTOM_BIN_DIR"
 fi
 
-# Download the binary file
 echo "Downloading $BINARY_NAME from $BINARY_URL"
 curl -L -o "$CUSTOM_BIN_DIR/$BINARY_NAME" "$BINARY_URL"
 if [[ $? -ne 0 ]]; then
@@ -25,11 +22,9 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
-# Ensure the binary is executable
 echo "Making $CUSTOM_BIN_DIR/$BINARY_NAME executable"
 chmod +x "$CUSTOM_BIN_DIR/$BINARY_NAME"
 
-# Display instructions for the user
 cat <<EOF
 
 Installation complete!

--- a/setup-windows.cmd
+++ b/setup-windows.cmd
@@ -1,25 +1,21 @@
 @echo off
 setlocal
 
-:: Variables
 set "BINARY_NAME=commit_message.exe"
 set "CUSTOM_BIN_DIR=%UserProfile%\bin"
 set "BINARY_URL=https://github.com/MatthewAraujo/commit_message/releases/download/binary/commit_message.exe"
 
-:: Check for curl
 where curl >nul 2>nul
 if errorlevel 1 (
     echo Error: curl is required but not installed. Please install curl and try again.
     exit /b 1
 )
 
-:: Create the custom directory if it doesn't exist
 if not exist "%CUSTOM_BIN_DIR%" (
     echo Creating directory: %CUSTOM_BIN_DIR%
     mkdir "%CUSTOM_BIN_DIR%"
 )
 
-:: Download the binary file
 echo Downloading %BINARY_NAME% from %BINARY_URL%
 curl -L -o "%CUSTOM_BIN_DIR%\%BINARY_NAME%" "%BINARY_URL%"
 if errorlevel 1 (
@@ -27,7 +23,6 @@ if errorlevel 1 (
     exit /b 1
 )
 
-:: Add the custom directory to the PATH
 echo Adding %CUSTOM_BIN_DIR% to the PATH
 for /f "tokens=2* delims=;" %%A in ('reg query "HKCU\Environment" /v PATH 2^>nul') do (
     set "CURRENT_PATH=%%B"
@@ -35,6 +30,5 @@ for /f "tokens=2* delims=;" %%A in ('reg query "HKCU\Environment" /v PATH 2^>nul
 if not defined CURRENT_PATH set "CURRENT_PATH="
 setx PATH "%CUSTOM_BIN_DIR%;%CURRENT_PATH%" >nul
 
-:: Confirm completion
 echo.
 echo Installation complete! You can now run "%BINARY_NAME%" from any command prompt.


### PR DESCRIPTION
 - Cleaned up the `setup-linux.sh` and `setup-windows.cmd` scripts by removing redundant comments to improve readability. Key changes include:
 - Removed comments explaining straightforward steps that are self-explanatory.
 - Retained important messages and directions needed for installation processes.
 - Ensured functionality remains unchanged for both Linux and Windows scripts.